### PR TITLE
Add Next.js chat UI with streaming API

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+LOCAL_API_BASE=http://localhost:3000
+MODEL=gpt-oss-20b

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals", "prettier"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# WEBUI2
-WEBUI2
+# ローカルモデルチャット
+
+Next.js 14 と Tailwind CSS を使ったシンプルなチャット UI です。LM Studio で起動したローカル LLM と通信します。
+
+## セットアップ
+
+```bash
+pnpm install
+pnpm dev
+```
+
+`http://localhost:3000` でアプリが起動します。
+
+## 環境変数
+
+`.env.local` を作成し、以下を設定してください。
+
+```
+LOCAL_API_BASE=http://localhost:3000
+MODEL=gpt-oss-20b
+```
+
+## LM Studio 側の設定
+1. LM Studio を起動し、`gpt-oss-20b` などのモデルを読み込みます。
+2. 「Server」タブで **PORT 1234** の API サーバーを起動します。
+3. アプリからのリクエストが `http://127.0.0.1:1234` に届くようにします。
+
+これでブラウザからローカルモデルとチャットできます。

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,30 @@
+import type { NextRequest } from 'next/server';
+
+interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const { messages } = (await req.json()) as { messages: ChatMessage[] };
+
+  const res = await fetch('http://127.0.0.1:1234/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: process.env.MODEL ?? 'gpt-oss-20b',
+      messages,
+      stream: true,
+    }),
+  });
+
+  if (!res.body) {
+    return new Response('No stream', { status: 500 });
+  }
+
+  return new Response(res.body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+    },
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import type { FC, ReactNode } from 'react';
+
+export const metadata = {
+  title: 'チャット',
+  description: 'ローカルモデルとのチャットデモ',
+};
+
+interface Props {
+  children: ReactNode;
+}
+
+const RootLayout: FC<Props> = ({ children }) => (
+  <html lang="ja">
+    <body className="bg-gray-50">{children}</body>
+  </html>
+);
+
+export default RootLayout;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { FC, FormEvent, useEffect, useRef, useState } from 'react';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const HomePage: FC = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState<string>('');
+  const [streaming, setStreaming] = useState<boolean>(false);
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault();
+    if (!input.trim() || streaming) return;
+    const userMessage: ChatMessage = { role: 'user', content: input };
+    const newMessages = [...messages, userMessage];
+    setMessages(newMessages);
+    setInput('');
+    setStreaming(true);
+
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: newMessages }),
+    });
+
+    if (!res.body) {
+      setStreaming(false);
+      return;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let done = false;
+    setMessages((msgs) => [...msgs, { role: 'assistant', content: '' }]);
+
+    while (!done) {
+      const { value, done: doneReading } = await reader.read();
+      done = doneReading;
+      const chunkValue = decoder.decode(value);
+      const lines = chunkValue.split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data:')) continue;
+        const data = trimmed.replace(/^data:\s*/, '');
+        if (data === '[DONE]') {
+          setStreaming(false);
+          return;
+        }
+        try {
+          const json = JSON.parse(data);
+          const text: string = json.choices?.[0]?.delta?.content ?? '';
+          if (text) {
+            setMessages((msgs) => {
+              const updated = [...msgs];
+              updated[updated.length - 1].content += text;
+              return updated;
+            });
+          }
+        } catch {
+          // ignore malformed JSON
+        }
+      }
+    }
+    setStreaming(false);
+  };
+
+  return (
+    <main className="flex h-screen flex-col">
+      <div className="flex-1 overflow-y-auto p-4">
+        {messages.map((m, idx) => (
+          <div
+            key={idx}
+            className={`mb-2 flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`max-w-xs rounded px-3 py-2 text-sm md:max-w-md ${
+                m.role === 'user'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 text-gray-900'
+              }`}
+            >
+              {m.content}
+              {streaming && idx === messages.length - 1 && m.role === 'assistant'
+                ? '…'
+                : ''}
+            </div>
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <form
+        onSubmit={handleSubmit}
+        className="flex gap-2 border-t bg-white p-4"
+      >
+        <input
+          type="text"
+          className="flex-1 rounded border px-3 py-2"
+          placeholder="メッセージを入力"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="rounded bg-blue-500 px-4 py-2 text-white disabled:opacity-50"
+          disabled={streaming}
+        >
+          送信
+        </button>
+      </form>
+    </main>
+  );
+};
+
+export default HomePage;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "nextjs-chat",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.20",
+    "@types/node": "20.5.1",
+    "autoprefixer": "10.4.14",
+    "eslint": "8.49.0",
+    "eslint-config-next": "14.0.0",
+    "postcss": "8.4.27",
+    "prettier": "3.0.3",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.1.6"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 project with TypeScript and Tailwind
- add streaming chat API proxy and responsive chat UI

## Testing
- `pnpm lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68940f48fa788322a4752b6fa22f520a